### PR TITLE
Initialise motorSimAxis::delayedDone_

### DIFF
--- a/motorSimApp/src/motorSimDriver.cpp
+++ b/motorSimApp/src/motorSimDriver.cpp
@@ -68,6 +68,7 @@ motorSimAxis::motorSimAxis(motorSimController *pController, int axis, double low
   nextpoint_.axis[0].p = start;
   route_ = routeNew( &(this->endpoint_), &pars );
   deferred_move_ = 0;
+  delayedDone_ = 0;
 }
 
 


### PR DESCRIPTION
The `delayedDone_` member of `motorSimAxis` isn't explicitly initialised, so it takes on an unpredictable value (whatever was in that memory already). If this isn't 0 or 1, the delayed done logic appears to get stuck. DMOV is stuck at 0, and the axis doesn't respond to move commands (RBV remains at 0).

Initialising it to 0 seems to fix it.

In testing with the example IOC, this problem only affected the first axis. I assume that's because the other axes happened to get lucky and `delayedDone_` was initialised to 0 (or 1) but that will depend on compiler and architecture. In any case, I think this fixes #12.